### PR TITLE
dasharo: add Dasharo Tools Suite (Nightly) iPXE menu entry

### DIFF
--- a/dasharo/dasharo.ipxe
+++ b/dasharo/dasharo.ipxe
@@ -9,6 +9,7 @@ menu
 item --gap -- ------------------------ Dasharo Network Boot Menu ------------------------
 item boot           Autoboot (DHCP)
 item dasharo        Dasharo Tools Suite
+item dasharo_nightly Dasharo Tools Suite (Nightly)
 item netbootxyz     OS installation (netboot.xyz official server)
 item shell          iPXE Shell
 choose --default boot --timeout 3000 target && goto ${target}
@@ -21,6 +22,11 @@ goto MENU
 :dasharo
 dhcp ||
 chain https://boot.dasharo.com/dts/dts.ipxe ||
+goto MENU
+
+:dasharo_nightly
+dhcp ||
+chain https://boot.dasharo.com/dts/nightly.ipxe ||
 goto MENU
 
 :netbootxyz


### PR DESCRIPTION
This PR adds a new "Dasharo Tools Suite (Nightly)" entry to the Dasharo iPXE network boot menu, which chains to `https://boot.dasharo.com/dts/nightly.ipxe` (nightly DTS builds from the `develop` branch).

The new entry is placed directly after the existing "Dasharo Tools Suite" entry, as requested in the issue. The handler follows the same pattern as the stable DTS entry (`dhcp || chain <url> || goto MENU`).

## Verification

Tested on QEMU Q35 with Dasharo coreboot firmware (v0.2.1-rc1). See screenshots.

To reproduce:

1. Clone coreboot repo and apply the iPXE change
2. Set up swtpm + QEMU with a NIC.
3. In UEFI Setup, enable network boot
4. After reboot, go to One Time Boot → iPXE Network Boot

### Before (pre-built v0.2.1-rc1 ROM — 4 entries, no Nightly)

<img width="800" height="600" alt="before-4-entries" src="https://github.com/user-attachments/assets/71cb28c3-4d1b-4b84-bbbf-2469c44f08cb" />

### After (custom ROM with modified dasharo.ipxe — 5 entries with Nightly)

<img width="800" height="600" alt="after-5-entries-countdown3" src="https://github.com/user-attachments/assets/a97c9375-175a-4ad1-b35b-db254b1503fa" />

## Checklist

- [x] Menu entry appears in correct position (after DTS stable, before netboot.xyz)
- [x] Menu label matches expected format: "Dasharo Tools Suite (Nightly)"
- [x] Handler chains to correct URL: `https://boot.dasharo.com/dts/nightly.ipxe`
- [x] `nightly.ipxe` endpoint is live and returns a valid iPXE script
- [x] Existing menu entries and behavior are unchanged
- [x] Autoboot default + 3s timeout still works as before

## Open items

- **OSFV tests**: The network-boot.robot tests in [open-source-firmware-validation](https://github.com/Dasharo/open-source-firmware-validation/blob/develop/dasharo-compatibility/network-boot.robot) will need updating to expect 5 menu entries instead of 4.
- **nightly.ipxe availability**: Confirmed the endpoint is live (`HTTP 200`, serves a valid iPXE script referencing `nightly/bzImage` and `nightly/dts-base-image.cpio.gz`). Per the issue, availability of functional nightly builds should be confirmed with @DaniilKl.

Resolves: Dasharo/dasharo-issues#1041
