### PR TITLE
dasharo: add Nightly DTS entry to iPXE network menu

### DIFF
--- a/dasharo/dasharo.ipxe
+++ b/dasharo/dasharo.ipxe
@@ -9,6 +9,7 @@ menu
 item --gap -- ------------------------ Dasharo Network Boot Menu ------------------------
 item boot           Autoboot (DHCP)
 item dasharo        Dasharo Tools Suite
+item dasharo_nightly Dasharo Tools Suite (Nightly)
 item netbootxyz     OS installation (netboot.xyz official server)
 item shell          iPXE Shell
 choose --default boot --timeout 3000 target && goto ${target}
@@ -23,6 +24,11 @@ dhcp ||
 chain https://boot.dasharo.com/dts/dts.ipxe ||
 goto MENU
 
+:dasharo_nightly
+dhcp ||
+chain https://boot.dasharo.com/dts/nightly.ipxe ||
+goto MENU
+
 :netbootxyz
 dhcp ||
 chain https://boot.netboot.xyz/menu.ipxe ||
@@ -34,4 +40,3 @@ shell ||
 goto MENU
 
 autoboot
-


### PR DESCRIPTION
## What
- add `Dasharo Tools Suite (Nightly)` to the main iPXE menu, right after the stable DTS entry
- add a dedicated `:dasharo_nightly` handler that chains to `https://boot.dasharo.com/dts/nightly.ipxe`
- keep fallback behavior consistent with the existing entries (`dhcp || chain || goto MENU`)

## Why
Issue `Dasharo/dasharo-issues#1041` requests exposing nightly DTS builds directly from the Dasharo iPXE menu.

## Notes
OSFV test updates are submitted in a companion PR:
- `Dasharo/open-source-firmware-validation` (network-boot menu order + nightly option coverage)

Fixes Dasharo/dasharo-issues#1041