### PR TITLE
feat: add DTS nightly iPXE menu entry

### DIFF
--- a/dasharo/dasharo.ipxe
+++ b/dasharo/dasharo.ipxe
@@ -9,6 +9,7 @@ menu
 item --gap -- ------------------------ Dasharo Network Boot Menu ------------------------
 item boot           Autoboot (DHCP)
 item dasharo        Dasharo Tools Suite
+item dasharo-nightly Dasharo Tools Suite (Nightly)
 item netbootxyz     OS installation (netboot.xyz official server)
 item shell          iPXE Shell
 choose --default boot --timeout 3000 target && goto ${target}
@@ -21,6 +22,11 @@ goto MENU
 :dasharo
 dhcp ||
 chain https://boot.dasharo.com/dts/dts.ipxe ||
+goto MENU
+
+:dasharo-nightly
+dhcp ||
+chain https://boot.dasharo.com/dts/nightly.ipxe ||
 goto MENU
 
 :netbootxyz


### PR DESCRIPTION
## Summary
- Adds a `Dasharo Tools Suite (Nightly)` item next to the existing stable DTS iPXE menu item.
- Chains the new menu target to `https://boot.dasharo.com/dts/nightly.ipxe`.
- Returns to the main iPXE menu on chain failure, matching the existing stable DTS behavior.

Part of Dasharo/dasharo-issues#1041.

## Verification
- `curl -fsSLI https://boot.dasharo.com/dts/nightly.ipxe`
- static assertion for the new menu item, target label, and nightly chain URL
- `git diff --check`
