### PR TITLE
dasharo: add Dasharo Tools Suite (Nightly) to iPXE menu

### DIFF
--- a/dasharo/dasharo.ipxe
+++ b/dasharo/dasharo.ipxe
@@ -9,6 +9,7 @@ menu
 item --gap -- ------------------------ Dasharo Network Boot Menu ------------------------
 item boot           Autoboot (DHCP)
 item dasharo        Dasharo Tools Suite
+item dasharo_nightly Dasharo Tools Suite (Nightly)
 item netbootxyz     OS installation (netboot.xyz official server)
 item shell          iPXE Shell
 choose --default boot --timeout 3000 target && goto ${target}
@@ -21,6 +22,11 @@ goto MENU
 :dasharo
 dhcp || goto dhcp_failed
 chain https://boot.dasharo.com/dts/dts.ipxe || goto dts_failed
+goto MENU
+
+:dasharo_nightly
+dhcp || goto dhcp_failed
+chain https://boot.dasharo.com/dts/nightly.ipxe || goto dts_nightly_failed
 goto MENU
 
 :netbootxyz
@@ -45,6 +51,11 @@ goto MENU
 
 :dts_failed
 echo Loading DTS failed.
+prompt Press any key to return to menu...
+goto MENU
+
+:dts_nightly_failed
+echo Loading DTS Nightly failed.
 prompt Press any key to return to menu...
 goto MENU
 


### PR DESCRIPTION
## Summary

Adds a new iPXE menu entry for **Dasharo Tools Suite (Nightly)** which boots from `https://boot.dasharo.com/dts/nightly.ipxe` where nightly builds from the `develop` branch land.

Addresses [Dasharo/dasharo-issues#1041](https://github.com/Dasharo/dasharo-issues/issues/1041)

## Changes

- Added `dasharo_nightly` menu item in the iPXE menu (placed after the stable DTS entry)
- Added `:dasharo_nightly` boot section that chains to `nightly.ipxe`
- Added `:dts_nightly_failed` error handler with user-friendly message

## Testing

This can be tested on QEMU by:
1. Building Dasharo firmware for QEMU Q35 with this updated iPXE script
2. Booting the firmware and selecting "Dasharo Tools Suite (Nightly)" from the network boot menu
3. Verifying that it attempts to chain-load from `boot.dasharo.com/dts/nightly.ipxe`

## Note

As mentioned in the bounty issue, `nightly.ipxe` should only lead to a functional build when agreed upon with @DaniilKl. The menu entry is ready; the backend `nightly.ipxe` endpoint needs to serve functional builds for this to work end-to-end.

**Bounty**: This addresses the $100 bounty-easy issue Dasharo/dasharo-issues#1041